### PR TITLE
Potential fix for code scanning alert no. 28: Double escaping or unescaping

### DIFF
--- a/phpBB/assets/javascript/editor.js
+++ b/phpBB/assets/javascript/editor.js
@@ -201,8 +201,8 @@ function addquote(post_id, username, l_wrote, attributes) {
 			theSelection = theSelection.replace(/<br\/>/ig, '\n');
 			theSelection = theSelection.replace(/&lt\;/ig, '<');
 			theSelection = theSelection.replace(/&gt\;/ig, '>');
-			theSelection = theSelection.replace(/&amp\;/ig, '&');
 			theSelection = theSelection.replace(/&nbsp\;/ig, ' ');
+			theSelection = theSelection.replace(/&amp\;/ig, '&');
 		} else if (document.all) {
 			theSelection = divarea.innerText;
 		} else if (divarea.textContent) {


### PR DESCRIPTION
Potential fix for [https://github.com/avocadosmash/phpbb-lab/security/code-scanning/28](https://github.com/avocadosmash/phpbb-lab/security/code-scanning/28)

https://github.com/avocadosmash/phpbb-lab/security/code-scanning/29

To correct double unescaping errors, always unescape the escape character (`&amp;`) last. In this JavaScript code, that means lines unescaping other HTML entities (`&lt;`, `&gt;`, `&nbsp;`) should precede the line unescaping `&amp;`, so that a string like `&amp;nbsp;` is first decoded to `&nbsp;`, then unescaped to a space only after the ampersand is decoded.  

Specifically, in `addquote`, adjust the sequence of the `.replace()` calls so that `theSelection.replace(/&amp\;/ig, '&')` comes after all other lines that match an `&...;` entity, notably after both `&lt;`, `&gt;`, and `&nbsp;`.  

No new imports or methods are required, but care should be taken to maintain the overall logic and whitespace.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
